### PR TITLE
Dev container定義と利用手順を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"azure-cli": "latest"
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip3 install -r requirements.txt"
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ Azure AD認証する例です。
 ## 使い方
 
 ### パッケージのインストール
-
+#### Option 1: Pythonが既にローカルにインストールされている場合
 ```bash
 pip install -r requirements.txt
 ```
+#### Option 2: dev containerを使う場合
+以下の手順を使うと、`.devcontainer/devcontainer.json`に指定しているdev containerが起動し、その中からVS Codeが起動します。Python・Azure CLI・requirementsがインストールされている環境でVS Codeが再起動されます。
+1. VS CodeのCommand Palette（Ctrl + Shift + P）を開き
+2. Dev Containers: Reopen in Containerを選択
 
 ### APIキーの定義
 


### PR DESCRIPTION
Dev container定義と利用手順を追加しました。
Pythonを事前にインストールしていないユーザ等にとって良いと思います。